### PR TITLE
Add de-dupe logic for dependency paths

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 
 const { Readable } = require('stream');
 const {
+  dedupeList,
   findNodeModules,
   findUsedModules,
   toRelativeModulePath,
@@ -13,8 +14,9 @@ const {
     const params = parseArgs(process.argv);
 
     const handler = params.entry ? handleEntry : handlePackJSON;
-    const result = (await handler(params))
+    const rawResult = (await handler(params))
       .map(toRelativeModulePath);
+    const result = dedupeList(rawResult);
     if (params.zip) zip(result, params);
 
     const output = formatOutput(result, params);

--- a/lib/dedupe-list.js
+++ b/lib/dedupe-list.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+module.exports = dedupeList;
+
+function dedupeList (list) {
+  const sorted = [...list].sort();
+  const seen = {};
+  return sorted.filter((item) => {
+    const parts = item.split(path.sep);
+    let dupe = seen[item];
+    while (!dupe && parts.length > 1) {
+      if (seen[parts.join(path.sep)]) {
+        dupe = true;
+      } else {
+        parts.pop();
+      }
+    }
+    seen[item] = true;
+    return !dupe;
+  });
+}

--- a/lib/dedupe-list.spec.js
+++ b/lib/dedupe-list.spec.js
@@ -1,0 +1,30 @@
+const dedupeList = require('./dedupe-list');
+
+describe('dedupeList', () => {
+  it('should sort and dedupe paths (and subpaths)', () => {
+    expect(dedupeList([
+      '../../node_modules/aws-serverless-express',
+      '../../node_modules/send/node_modules/ms',
+      '../../node_modules/express',
+      '../../node_modules/send/node_modules/http-errors',
+      '../../node_modules/morgan',
+      '../../node_modules/cookie-signature',
+      '../../node_modules/send',
+      '../../node_modules/morgan',
+      '../../node_modules/cookie/node_modules/something',
+      '../../node_modules/cors',
+      '../../node_modules/morgan',
+      '../../node_modules/send/node_modules/ms',
+      '../../node_modules/morgan',
+      '../../node_modules/cookie'
+    ])).toEqual([
+      '../../node_modules/aws-serverless-express',
+      '../../node_modules/cookie',
+      '../../node_modules/cookie-signature',
+      '../../node_modules/cors',
+      '../../node_modules/express',
+      '../../node_modules/morgan',
+      '../../node_modules/send'
+    ]);
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+module.exports.dedupeList = require('./dedupe-list');
 module.exports.findNodeModules = require('./find-node-modules');
 module.exports.findUsedModules = require('./find-used-modules');
 module.exports.toRelativeModulePath = require('./to-relative-module-path');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",


### PR DESCRIPTION
Removes redundant paths (and their subpaths) from output to address #1 

Also includes a minor security version bump for subdependency `bl`.